### PR TITLE
Use latest go with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
-        with:
-          go-version: 1.17 # https://github.com/golangci/golangci-lint/issues/2649
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
It seems the Go 1.17 version issue has been resolved, let's see!